### PR TITLE
Fix thread safety warnings when building WO projects in parallel

### DIFF
--- a/src/main/java/org/wocommunity/maven/wolifecycle/DefineWOApplicationResourcesMojo.java
+++ b/src/main/java/org/wocommunity/maven/wolifecycle/DefineWOApplicationResourcesMojo.java
@@ -48,6 +48,7 @@ import org.apache.maven.project.MavenProject;
  * 
  * @goal define-woapplication-resources
  * @requiresDependencyResolution compile
+ * @threadSafe
  * @author uli
  * @author hprange
  * @since 2.0

--- a/src/main/java/org/wocommunity/maven/wolifecycle/DefineWOFrameworkResourcesMojo.java
+++ b/src/main/java/org/wocommunity/maven/wolifecycle/DefineWOFrameworkResourcesMojo.java
@@ -24,6 +24,7 @@ import org.apache.maven.project.MavenProject;
  * resources goal for WebObjects projects.
  * 
  * @goal define-woframework-resources
+ * @threadSafe
  * @author uli
  * @since 2.0
  */

--- a/src/main/java/org/wocommunity/maven/wolifecycle/PackageWOApplicationResourcesMojo.java
+++ b/src/main/java/org/wocommunity/maven/wolifecycle/PackageWOApplicationResourcesMojo.java
@@ -29,6 +29,7 @@ import org.apache.maven.project.MavenProject;
  * @phase package
  * @requiresProject
  * @requiresDependencyResolution compile
+ * @threadSafe
  * @author uli
  * @author hprange
  * @since 2.0

--- a/src/main/java/org/wocommunity/maven/wolifecycle/PackageWOFrameworkResourcesMojo.java
+++ b/src/main/java/org/wocommunity/maven/wolifecycle/PackageWOFrameworkResourcesMojo.java
@@ -29,6 +29,7 @@ import org.apache.maven.project.MavenProject;
  * @phase package
  * @requiresProject
  * @requiresDependencyResolution compile
+ * @threadSafe
  * @author uli
  * @author <a href="mailto:hprange@gmail.com">Henrique Prange</a>
  * @since 2.0


### PR DESCRIPTION
There is no evidence that this plugin isn't thread-safe. So, let's make it thread-safe and avoid the noise.