### PR TITLE
Flatten component support

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,9 @@ Or to build a WO application package:
 
 This plugin comes with some options that you can change in the `configuration` section of the plugin.
 
-- **flattenResources**: Flatten all Resources and WebServerResouces into the Resources folder of the application/framework package.
-- **readPatternsets**: Include Resources and WebResources files according to an existing patternset files.
+- **flattenResources**: Flatten all Resources and WebServerResouces into the Resources folder of the application/framework package. All nested folders other than wo and eomodeld are dissolved.
+- **flattenComponents**: Flatten only the WOComponents and EOModels from Resources or Components folders. All other files and directories keep their original nesting structure. 
+- **readPatternsets**: Include Resources and WebResources files according to an existing patternset files in the woproject folder. The files here get added *in addition* to anything in the Resources and Component folders processed by default. Also those files and folders will not get flattened.
 - **skipAppleProvidedFrameworks**: Do not include Apple WebObjects libraries when building application packages.
 - **includeJavaClientClassesInWebServerResources**: Include  JavaClientClasses in the WebServerResources package.
 

--- a/src/main/java/org/wocommunity/maven/wolifecycle/AbstractPackageMojo.java
+++ b/src/main/java/org/wocommunity/maven/wolifecycle/AbstractPackageMojo.java
@@ -32,6 +32,7 @@ public abstract class AbstractPackageMojo extends AbstractWOMojo {
 	super();
     }
 
+    @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
 	getLog().info("Packaging WebObjects project");
 

--- a/src/main/java/org/wocommunity/maven/wolifecycle/DefineWOApplicationResourcesMojo.java
+++ b/src/main/java/org/wocommunity/maven/wolifecycle/DefineWOApplicationResourcesMojo.java
@@ -136,11 +136,9 @@ public class DefineWOApplicationResourcesMojo extends
 	}
 	file.createNewFile();
 
-	InputStream is = null;
-	OutputStream os = null;
-	try {
-	    is = new JarFile(jarFileName).getInputStream(jarEntry);
-	    os = new FileOutputStream(file);
+	try (JarFile jarf = new JarFile(jarFileName);
+             InputStream is = jarf.getInputStream(jarEntry);
+             OutputStream os = new FileOutputStream(file)) {
 
 	    byte[] buf = new byte[1024];
 	    int len;
@@ -148,14 +146,6 @@ public class DefineWOApplicationResourcesMojo extends
 		os.write(buf, 0, len);
 	    }
 
-	} finally {
-	    if (is != null) {
-		is.close();
-	    }
-
-	    if (os != null) {
-		os.close();
-	    }
 	}
     }
 
@@ -270,11 +260,8 @@ public class DefineWOApplicationResourcesMojo extends
 		continue;
 	    }
 
-	    try {
-		FileInputStream fileInputStream = new FileInputStream(jarFile);
-
-		JarInputStream jarInputStream = new JarInputStream(
-			fileInputStream);
+	    try (FileInputStream fileInputStream = new FileInputStream(jarFile);
+                 JarInputStream jarInputStream = new JarInputStream(fileInputStream)) {
 
 		int counter = 0;
 
@@ -301,11 +288,8 @@ public class DefineWOApplicationResourcesMojo extends
 			}
 		    }
 		}
-		getLog()
-			.debug(
-				counter
-					+ " WebServerResources was extracted and copied from Jar named "
-					+ jarFile.getName());
+		getLog().debug(counter + " WebServerResources was extracted and copied from Jar named "
+				       + jarFile.getName());
 	    } catch (FileNotFoundException e) {
 		throw new MojoExecutionException("Could not open file ('"
 			+ jarFile.getName() + "') input stream", e);
@@ -342,7 +326,7 @@ public class DefineWOApplicationResourcesMojo extends
 	return true;
     }
 
-    private boolean isArtifactDeployed(final File file) {
+    private static boolean isArtifactDeployed(final File file) {
 	return file.isFile();
     }
 

--- a/src/main/java/org/wocommunity/maven/wolifecycle/PatternsetReader.java
+++ b/src/main/java/org/wocommunity/maven/wolifecycle/PatternsetReader.java
@@ -33,10 +33,8 @@ public class PatternsetReader {
 
 	List<String> patternList = new ArrayList<String>();
 
-	BufferedReader patternReader = null;
-
-	try {
-	    patternReader = new BufferedReader(new FileReader(patternset));
+	try (FileReader fr = new FileReader(patternset);
+             BufferedReader patternReader = new BufferedReader(fr)) {
 
 	    String line = patternReader.readLine();
 
@@ -46,14 +44,6 @@ public class PatternsetReader {
 		}
 
 		line = patternReader.readLine();
-	    }
-	} finally {
-	    if (null != patternReader) {
-		try {
-		    patternReader.close();
-		} catch (IOException ioe) {
-		    // Ignore exception
-		}
 	    }
 	}
 

--- a/src/test/java/org/wocommunity/maven/wolifecycle/MockWOMojo.java
+++ b/src/test/java/org/wocommunity/maven/wolifecycle/MockWOMojo.java
@@ -18,7 +18,6 @@ package org.wocommunity.maven.wolifecycle;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.project.MavenProject;
-import org.wocommunity.maven.wolifecycle.AbstractWOMojo;
 
 /**
  * Only to test methods on abstract class
@@ -27,6 +26,7 @@ import org.wocommunity.maven.wolifecycle.AbstractWOMojo;
  */
 public class MockWOMojo extends AbstractWOMojo {
 
+    @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
 	// Do nothing
     }

--- a/src/test/java/org/wocommunity/maven/wolifecycle/TestAbstractDefineResourcesMojo.java
+++ b/src/test/java/org/wocommunity/maven/wolifecycle/TestAbstractDefineResourcesMojo.java
@@ -29,7 +29,6 @@ import org.apache.maven.plugin.testing.AbstractMojoTestCase;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
-import org.wocommunity.maven.wolifecycle.AbstractDefineResourcesMojo;
 
 public class TestAbstractDefineResourcesMojo extends AbstractMojoTestCase {
     private static final File TEST_POM = new File(getBasedir(),
@@ -93,7 +92,7 @@ public class TestAbstractDefineResourcesMojo extends AbstractMojoTestCase {
 
 	File file = Mockito.spy(new File(".svn"));
 
-	Mockito.stub(file.isHidden()).toReturn(true);
+	Mockito.when(file.isHidden()).thenReturn(true);
 
 	assertThat(mojo.includeResourcesRecursively(file), is(false));
     }
@@ -130,7 +129,7 @@ public class TestAbstractDefineResourcesMojo extends AbstractMojoTestCase {
     public void testFullTargetDirectoryNotIncludingVersion() throws Exception {
 	mojo = Mockito.spy(mojo);
 
-	Mockito.stub(mojo.includesVersionInArtifactName()).toReturn(false);
+	Mockito.when(mojo.includesVersionInArtifactName()).thenReturn(false);
 
 	String path = mojo.getFullTargetPath("folder");
 


### PR DESCRIPTION
This introduces a new option "flattenComponent". The option is similar to flattenResources, but will leave non WOComponent/EOModeld folder hierarchies intact. The resulting folder structure should be very similar to the one produced by WOLips.

Reason for this change: I have a project with many components, organised in subfolders of the Components folders. Those components must get flattened into to application Resources to be useful. But I have also a folder hierarchy in Resources and WebServerResourced, that should be copied as they are. While flattenResources will either flatten all those components and files or none, this new option flattens only components.

There is also a little bit of code cleanup, mostly warning from the compiler.