### PR TITLE
Add runtime-scoped dependencies to application bundle

### DIFF
--- a/src/main/java/org/wocommunity/maven/wolifecycle/DefineWOApplicationResourcesMojo.java
+++ b/src/main/java/org/wocommunity/maven/wolifecycle/DefineWOApplicationResourcesMojo.java
@@ -47,10 +47,11 @@ import org.apache.maven.project.MavenProject;
  * resources goal for WebObjects projects.
  * 
  * @goal define-woapplication-resources
- * @requiresDependencyResolution compile
+ * @requiresDependencyResolution compile+runtime
  * @threadSafe
  * @author uli
  * @author hprange
+ * @author paulh
  * @since 2.0
  */
 public class DefineWOApplicationResourcesMojo extends


### PR DESCRIPTION
The `package` target for WOApplications was not including `runtime`-scoped dependencies in the application bundle, which would lead to application failure in projects with such dependencies. This pull request ensures that `runtime`-scoped dependencies are included in the application bundle.