### PR TITLE
Fixes broken continuous integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 language: java
 jdk:
   - openjdk7


### PR DESCRIPTION
Some [light Googling](https://travis-ci.community/t/error-installing-oraclejdk8-expected-feature-release-number-in-range-of-9-to-14-but-got-8/3766) suggested that Travis changed the default underlying Linux distribution at some point, which lead to the broken builds we've been seeing on this project recently. The fix is to explicitly declare a known-good distro:

    dist: trusty
