### PR TITLE
Typo in log output

### DIFF
--- a/src/main/java/org/wocommunity/maven/wolifecycle/DefineWOApplicationResourcesMojo.java
+++ b/src/main/java/org/wocommunity/maven/wolifecycle/DefineWOApplicationResourcesMojo.java
@@ -235,7 +235,7 @@ public class DefineWOApplicationResourcesMojo extends
     }
 
     private void executeCopyWebServerResources() throws MojoExecutionException {
-	getLog().info("Coping WebServerResources");
+	getLog().info("Copying WebServerResources");
 
 	@SuppressWarnings("unchecked")
 	Set<Artifact> artifacts = project.getArtifacts();


### PR DESCRIPTION
This fixes a typo in log output: `Coping WebServerResources` → `Copying WebServerResources`.