### PR TITLE
Fix error causing duplication of EO models under Resources

### DIFF
--- a/src/main/java/org/wocommunity/maven/wolifecycle/AbstractDefineResourcesMojo.java
+++ b/src/main/java/org/wocommunity/maven/wolifecycle/AbstractDefineResourcesMojo.java
@@ -170,9 +170,9 @@ public abstract class AbstractDefineResourcesMojo extends AbstractWOMojo {
                 resource.addInclude("*");
                 resource.addInclude("*/");
                 // but exclude wo, api and models in all subdirectories
-                resource.addExclude("*/**/*.wo/**");
+                resource.addExclude("*/**/*.wo/*");
                 resource.addExclude("*/**/*.api");
-                resource.addExclude("*/**/*.eomodeld/**");
+                resource.addExclude("*/**/*.eomodeld/*");
                 resource.addExclude("*/**/*.eogen");
             }
         }

--- a/src/main/java/org/wocommunity/maven/wolifecycle/AbstractDefineResourcesMojo.java
+++ b/src/main/java/org/wocommunity/maven/wolifecycle/AbstractDefineResourcesMojo.java
@@ -163,6 +163,7 @@ public abstract class AbstractDefineResourcesMojo extends AbstractWOMojo {
             resource.addInclude("*.wo/**");
             resource.addInclude("*.api");
             resource.addInclude("*.eomodeld/**");
+            resource.addInclude("*.eogen");
 
             // add all other things at the resource root directory also
             if (isResourceRoot) {
@@ -172,6 +173,7 @@ public abstract class AbstractDefineResourcesMojo extends AbstractWOMojo {
                 resource.addExclude("*/**/*.wo/**");
                 resource.addExclude("*/**/*.api");
                 resource.addExclude("*/**/*.eomodeld/**");
+                resource.addExclude("*/**/*.eogen");
             }
         }
 

--- a/src/main/java/org/wocommunity/maven/wolifecycle/AbstractDefineResourcesMojo.java
+++ b/src/main/java/org/wocommunity/maven/wolifecycle/AbstractDefineResourcesMojo.java
@@ -171,7 +171,7 @@ public abstract class AbstractDefineResourcesMojo extends AbstractWOMojo {
                 // but exclude wo, api and models in all subdirectories
                 resource.addExclude("*/**/*.wo/**");
                 resource.addExclude("*/**/*.api");
-                resource.addInclude("*/**/*.eomodeld/**");
+                resource.addExclude("*/**/*.eomodeld/**");
             }
         }
 


### PR DESCRIPTION
This pull request fixes issue #7 reported by @paulhoadley. It also moves `*.eogen` files along with `*.eomodeld` folders, keeping the behavior consistent with the `flattenResources` option.