### PR TITLE
Allow additional bundle options to be set during build

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 The wolifecycle-maven-plugin is a Maven plugin to assist in the development and packaging of WebObjects applications and frameworks.
 
-**Version**: 2.3
+**Version**: 2.4
 
 ## Usage
 
@@ -16,7 +16,7 @@ You must add the wolifecycle-maven-plugin to the `pom.xml` in the `build` sectio
     <plugin>
       <groupId>org.wocommunity</groupId>
       <artifactId>wolifecycle-maven-plugin</artifactId>
-      <version>2.3</version>
+      <version>2.4</version>
       <extensions>true</extensions>
     </plugin>
   </plugins>

--- a/src/main/scripts/wolifecycle.build.xml
+++ b/src/main/scripts/wolifecycle.build.xml
@@ -44,7 +44,7 @@
 		  </delete> -->
 
 
-		<woapplication name="${finalName}" frameworksBaseURL="/WebObjects/${finalName}.woa/Contents/Frameworks" startupScriptName="${artifactId}" stdFrameworks="false" destDir="target" customInfoPListContent="${customInfoPListContent}" principalClass="${principalClass}" cfBundleVersion="${version}" cfBundleShortVersion="${version}">
+		<woapplication name="${finalName}" frameworksBaseURL="/WebObjects/${finalName}.woa/Contents/Frameworks" startupScriptName="${artifactId}" stdFrameworks="false" destDir="target" customInfoPListContent="${customInfoPListContent}" principalClass="${principalClass}" cfBundleVersion="${version}" cfBundleShortVersion="${version}" jvm="${jvm}" jvmOptions="${jvmOptions}" jdb="${jdb}" jdbOptions="${jdbOptions}">
 			<classes dir="target/classes">
 			</classes>
 			<lib dir="${dependencies.lib}">


### PR DESCRIPTION
It's currently quite tricky to get certain JVM options set at application launch time. The launch script does some gymnastics to get JVM options into the right place on the command line: those starting with `-X`, for example, end up in the right place (that is, prior to the class name). But some, like the old `-server` and newer `--add-exports` are not moved into the right place by the launch script. The launch script _will_ honour the `JVMOptions` line in the header of the `*ClassPath.txt` files, but there's currently no mechanism for setting this using `wolifecycle-maven-plugin`.

So, all this pull request does is to update `wolifecycle.build.xml` to set the following when the `woapplication` Ant task builds the bundle:

* `jvm`
* `jvmOptions`
* `jdb`
* `jdbOptions`

Their values are pulled from properties of the same names, so you can set them in `build.properties`:

```
jvm=foo
jvmOptions=bar
jdb=bar
jdbOptions=quux
```