### PR TITLE
Sets 'jvm' to expected default.

### DIFF
--- a/src/main/scripts/wolifecycle.build.xml
+++ b/src/main/scripts/wolifecycle.build.xml
@@ -22,6 +22,7 @@
 	<!-- ================================================================== -->
 	<target name="woapplicationproperties" depends="test-pom">
 		<property file="build.properties" />
+		<property name="jvm" value="java"/>
 		<property file="target/wobuild.properties" />
 
 		<property file="target/classpath.properties" />


### PR DESCRIPTION
This fixes an issue in #15 where the literal string `${jvm}` ended up in `*ClassPath.txt` if `jvm` wasn't set in `build.properties`. Now, `java` is output instead, the expected default.