### PR TITLE
Skip "pom" artifacts when creating classpath.

### DIFF
--- a/src/main/java/org/wocommunity/maven/wolifecycle/DefineWOApplicationResourcesMojo.java
+++ b/src/main/java/org/wocommunity/maven/wolifecycle/DefineWOApplicationResourcesMojo.java
@@ -350,6 +350,11 @@ public class DefineWOApplicationResourcesMojo extends
 		Artifact.SCOPE_PROVIDED);
 
 	for (Artifact artifact : artifacts) {
+	    if ("pom".equals(artifact.getType())) {
+		// skip "pom" artifacts as they are no jars of their own
+		continue;
+	    }
+
 	    if (populateWebObjectsLibraries) {
 		if (!isWebObjectAppleGroup(artifact.getGroupId())) {
 		    continue;


### PR DESCRIPTION
Dependencies of type "pom" like

```
		<dependency>
		    <groupId>com.sun.xml.ws</groupId>
		    <artifactId>jaxws-ri</artifactId>
		    <version>3.0.2</version>
		    <type>pom</type>
		</dependency>
```

did include the proper sub dependencies, but the main dependency lead to an jar file which in fact was the pom file of this dependency. In this example we would get

com/sun/xml/ws/jaxws-ri/3.0.2/jaxws-ri-3.0.2.jar

with an invalid jar.

My proposed solution is to skip all "pom" artifacts when constructing the class path




